### PR TITLE
Check translations folder content

### DIFF
--- a/scripts/gettranslations.sh
+++ b/scripts/gettranslations.sh
@@ -48,6 +48,9 @@ HTTP_STATUS_CODE=$(printf "%s" "$RES" | tail -c 3)
 if [ "$HTTP_STATUS_CODE" -ne "200" ]  
 then
     echo "Failed to get translations from localization-api: $HTTP_STATUS_CODE"
+    FILES=(/"$translation_folder"/*)
+    if ! [ ${#FILES[@]} -gt 0 ]; then exit 1; fi
+
     if [ "$on_error_bypass" = true ]
     then
         exit 0


### PR DESCRIPTION
Check if translations folder contains at least one file with translations. If it does not, ignore the flag ‘on_error_bypass’ and finish the script execution with fail.